### PR TITLE
Made c9-setup.sh easier to use and understand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,45 +59,10 @@ Now, lets see how to accept the pull request if they end up liking it.
 4. Select PHP as the project type
 5. Wait for Cloud9 to set up the workspace
 You now have a local copy of your fork on which you can make changes.
-
-Now, you have to finish the process with a few terminal commands.
-
-Edit the server config file
-``` bash
-sudo nano /etc/apache2/sites-enabled/001-cloud9.conf
+Before you run the server, you have to set up the backend. The c9-setup.sh script does this for you. Just run:
+```shell
+sudo bash c9-setup.sh
 ```
-Change this line:
-``` apache
-DocumentRoot /home/ubuntu/workspace
-```
-to the following to tell the server where to find our public folder.
-``` apache
-DocumentRoot /home/ubuntu/workspace/public
-```
-To save the file, "Ctrl + X", then "y" for yes and "enter"
-
-Composer is used to install PHP packages. Make sure it is up-to-date
-``` bash
-sudo composer self-update
-```
-
-Install all dependencies needed for the project
-``` shell
-composer install
-```
-
-To use the database with MySQL, we need to setup your database connections. Make a .env file in your root directory.
-Define all the databse variables as listed in the .env.example file.  We use this as we do not share the same passwords and it is easier to collaborate.  The .env file is gitignored and does not get pushed to git so your passwords are safe to your local environment.
-
-#### Here are the default cloud9 credentials to connect MySQL:
-* DB_HOST: 127.0.0.1
-* DB_DATABASE= c9
-* DB_USERNAME='your c9 username'
-* DB_PASSWORD='blank'
-
-After this, open the file public/index.php and click the green run button to proceed to run this app as a PHP/Apache server.  Open the url given to you by the server terminal. Remember there's a difference between the Apache terminal and the bash terminal.
-
-You should get a message in the browser saying "conncted sucessfully to database named c9".  If you get the message, you are all setup.  If that does not occur, check your steps and troubleshoot. If you still need help, post and issue and we'll help you.
 
 ### How to Update your Fork
 Open the workspace folder of your fork and run this command:

--- a/README.md
+++ b/README.md
@@ -74,27 +74,26 @@ bash fork-update.sh develop
 Make sure that the fork-update.sh is the latest version. It will update itself
 
 Tutorials and Resources
-=======================
+-----------------------
 
-Tutorials for Everyone
-----------------------
-### Read up on these resources on how to use git effectively.
+### Tutorials for Everyone
+#### Read up on these resources on how to use git effectively.
 
 [Tutorial by Atlassian, GitHub's main competitor](https://www.atlassian.com/git/tutorials/)
 [Interactive Tutorial by Github](https://try.github.io/levels/1/challenges/1) - Sign in at first to track progress.
 
-### How to Use Cloud9
+#### How to Use Cloud9
 Browse [Cloud9's features](https://c9.io/#features)
 
 ### Frontend Tutorials
 
-#### Languages
-##### HTML and CSS
+##### Languages
+###### HTML and CSS
 HTML is a markup language that contains the content of a webpage. CSS helps explain how the content should be shown, but is not needed.
 * [Codecademy's Main Course](http://www.codecademy.com/skills/make-a-website)
 * [Codecademy's Other Course](http://www.codecademy.com/tracks/web)
 
-##### JavaScript or JS
+##### JavaScript AKA JS
 We will use JavaScript to make webpages interactive, but it can be used for much more.
 * [Codecademy's Other Course](http://www.codecademy.com/tracks/javascript)
 

--- a/c9-setup.sh
+++ b/c9-setup.sh
@@ -49,12 +49,6 @@ composer install; # install all dependencies
 	MAIL_USERNAME=null
 	MAIL_PASSWORD=null
 	" >> .env;
-	
-# run MySQL for moment and let it set itself up automatically
-delay=3; # in seconds, how long to let MySQL set up everything
-mysql-ctl start;
-sleep $delay; # give it some time to run
-mysql-ctl stop;
 
 echo "Setup process COMPLETE";
 echo "To start the server, run public/index.php in the right-click menu on C9";

--- a/c9-setup.sh
+++ b/c9-setup.sh
@@ -24,7 +24,7 @@
 	# $C9_USER is your Cloud9 username
 	# there is no password because no one else can use the database
 	
-	rm .env; # remove the current settings if they exist
+	rm .env -f; # forcefully remove the current settings file if it exists
 	touch .env; # make an empty file
 	
 	# this StackOverflow thread explains what is happening: http://goo.gl/Gf9L8Q

--- a/c9-setup.sh
+++ b/c9-setup.sh
@@ -5,20 +5,20 @@
 # bash c9-setup.sh
 
 # make Apache2 use the public folder as the website's root directory
-	fileDirectory="/etc/apache2/sites-enabled/001-cloud9.conf";
-	original="DocumentRoot /home/ubuntu/workspace";
-	corrected="DocumentRoot /home/ubuntu/workspace/public";
-	
-	if grep -q "$corrected" $fileDirectory; then
-		echo "Apache2 is already setup";
-	else
-		echo "Apache2 is being configured to use the public folder";
-		sed -i "s#$original#$corrected#g" $fileDirectory; # replace the text
-	fi;
+fileDirectory="/etc/apache2/sites-enabled/001-cloud9.conf";
+original="DocumentRoot /home/ubuntu/workspace";
+corrected="DocumentRoot /home/ubuntu/workspace/public";
+if grep -q "$corrected" $fileDirectory; then # if $corrected is already there...
+	echo "Apache2 is already setup";
+else
+	echo "Apache2 is being configured to use the public/ folder";
+	sed -i "s#$original#$corrected#g" $fileDirectory; # replace the text
+	echo "Apache2 is now configured to use the public/ folder"
+fi;
 
 # install the dependencies using PHP's Composer
-	sudo composer self-update; # make sure that it's up-to-date
-	composer install; # install all dependencies
+sudo composer self-update; # make sure that it's up-to-date
+composer install; # install all dependencies
 
 # make an environment file to manage MySQL
 	# $C9_USER is your Cloud9 username
@@ -28,6 +28,7 @@
 	touch .env; # make an empty file
 	
 	# this StackOverflow thread explains what is happening: http://goo.gl/Gf9L8Q
+	# tl;dr saves the settings into the .env file
 	printf "%s\n" "
 	APP_ENV=local
 	APP_DEBUG=true
@@ -49,10 +50,11 @@
 	MAIL_PASSWORD=null
 	" >> .env;
 	
-# let MySQL set itself up automatically
-	delay=3; # in seconds, how long to let MySQL set up everything
-	mysql-ctl start;
-	sleep $delay; # give it some time to run
-	mysql-ctl stop;
+# run MySQL for moment and let it set itself up automatically
+delay=3; # in seconds, how long to let MySQL set up everything
+mysql-ctl start;
+sleep $delay; # give it some time to run
+mysql-ctl stop;
 
 echo "Setup process COMPLETE";
+echo "To start the server, run public/index.php in the right-click menu on C9";

--- a/c9-setup.sh
+++ b/c9-setup.sh
@@ -9,7 +9,7 @@
 	original="DocumentRoot /home/ubuntu/workspace";
 	corrected="DocumentRoot /home/ubuntu/workspace/public";
 	
-	if grep -q this $fileDirectory; then
+	if grep -q "$corrected" $fileDirectory; then
 		echo "Apache2 is already setup";
 	else
 		echo "Apache2 is being configured to use the public folder";

--- a/update.sh
+++ b/update.sh
@@ -4,25 +4,18 @@
 # USE THIS COMMAND TO RUN THIS FILE:
 # bash update.sh
 
-# if [ "$1" == " " ]; then # if the first argument does not exist
-# #	branch="develop";
-#else
-#	branch=$1;
-#fi
-
 echo "Updating local develop branch";
 
-# set up the variables
+# refer to the original repository NOT the fork
 owner="Charles-T-King";
 repository="website";
 
-# avoid losing your work if there are conflicts
-#git add *; # add all the files
-#git stash; # avoid losing your work
-
+# make sure the upstream (original) repo is added
 git remote add upstream git://github.com/$owner/$repository.git
 git remote set-url upstream git://github.com/$owner/$repository.git
-git fetch upstream
-git rebase upstream/develop
+
+# update the local copy of the fork
+git fetch upstream # download upstream w/o changing anything
+git rebase upstream/develop # rebase is safer and cleaner than merge
 
 echo "Your fork is now synced with the upstream fork."


### PR DESCRIPTION
I did this by doing the following:
* Added more comments in the code
* Adding more log messages so it's more obvious what the script is doing
* Forcing the .env variable to be deleted to avoid having to ask for permission
* Reducing the amounts of frivolous indents

No new bugs should be in here because the functionality itself was not changed.