### PR TITLE
Uses link instead of Laravel Blade

### DIFF
--- a/resources/views/includes/head.blade.php
+++ b/resources/views/includes/head.blade.php
@@ -1,16 +1,9 @@
 <!-- Latest compiled and minified CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 
-<!-- Optional theme -->
-
-<!-- Latest compiled and minified JavaScript -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-
-<!-- Navigation Bar CSS -->
-{!! HTML::style('stylesheets/navbar.css') !!}
-
-<!-- CSS -->
-{!! HTML::style('stylesheets/styles.css') !!}
+<!--Custom Stylesheets-->
+<link rel="stylesheet" href="stylesheets/navbar.css">
+<link rel="stylesheet" href="stylesheets/styles.css">
 
 <!-- Font Awesome for Icons -->
 <link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
@@ -20,4 +13,3 @@
 
 <!-- Font Import -->
 <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
-

--- a/resources/views/includes/head.blade.php
+++ b/resources/views/includes/head.blade.php
@@ -1,15 +1,15 @@
-<!-- Latest compiled and minified CSS -->
+<!-- Bootstrap CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-
-<!--Custom Stylesheets-->
-<link rel="stylesheet" href="stylesheets/navbar.css">
-<link rel="stylesheet" href="stylesheets/styles.css">
 
 <!-- Font Awesome for Icons -->
 <link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 
-<!-- Favicon -->
+<!-- Our Favicon -->
 <link rel="icon" type="image/png" href="images/favicon.png">
 
-<!-- Font Import -->
+<!-- Fonts -->
 <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+
+<!-- Custom Stylesheets -->
+<link rel="stylesheet" href="stylesheets/navbar.css">
+<link rel="stylesheet" href="stylesheets/styles.css">


### PR DESCRIPTION
For some reason, it seems that the routing is not configured correctly for our CSS stylesheets, which means that the previous way of linking CSS files did not always work.

Instead, we should use the pure HTML version since that always works.